### PR TITLE
Add buildroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ $ # Get URL of container registry
 $ OSBS_REGISTRY=$(oc -n osbs-registry get route osbs-registry --output jsonpath='{ .spec.host }')
 
 $ # Copy base image for container build to registry
-$ # You might want to use skopeo-lite instead, more on that below
 $ skopeo copy docker://registry.fedoraproject.org/fedora:30 \
               docker://${OSBS_REGISTRY}/fedora:30 \
+              --all \
               --dest-tls-verify=false
 
 $ # Run koji container-build
@@ -23,6 +23,9 @@ $ oc -n osbs-koji rsh dc/koji-client \
           git://github.com/chmeliik/docker-hello-world#origin/osbs-box-basic \
           --git-branch osbs-box-basic
 ```
+
+If your version of `skopeo` does not support the `--all` flag, you might want to use `skopeo-lite`
+instead. More on that [here](#Skopeo-lite).
 
 
 ## Deployment
@@ -126,8 +129,11 @@ considered insecure. To access the registry with various tools you need to:
 
 ### Skopeo-lite
 
-Regular `skopeo` does not copy manifest lists. Builds may work even with base images copied using
-`skopeo`, but they will not use OSBS features related to manifest lists.
+__Starting with `skopeo` release `v0.1.40`, the `copy` command comes with an `--all` flag, which
+makes skopeo also copy manifest lists. That renders `skopeo-lite` obsolete.__
+
+Prior to `v0.1.40`, `skopeo` would not copy manifest lists. Builds may work even with base images
+missing manifest lists, but they will not use the related OSBS features.
 
 For this purpose, OSBS-Box provides a `skopeo-lite` image.
 

--- a/cleanup.yaml
+++ b/cleanup.yaml
@@ -99,9 +99,6 @@
       when: whoami.rc == 0
 
 
-# TODO: Delete OSBS buildroot
-
-
 - name: Delete persistent volume data
   hosts: localhost
   gather_facts: false

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -268,4 +268,28 @@
           - "system:build-strategy-custom"
 
 
-# TODO: Build OSBS buildroot
+- name: Build OSBS buildroot
+  hosts: localhost
+  gather_facts: false
+  tags:
+    - buildroot
+
+  tasks:
+    - name: Copy osbs-buildroot template to openshift files dir
+      copy:
+        src: openshift/templates/osbs-buildroot.yaml
+        dest: "{{ openshift_files }}/osbs-buildroot.yaml"
+
+    - name: Create openshift resources for osbs-buildroot
+      shell:
+        set -o pipefail;
+        oc process -f "{{ openshift_files }}/osbs-buildroot.yaml"
+                   --param-file "{{ openshift_files }}/osbs-box.env"
+                   --ignore-unknown-parameters |
+        oc --namespace "{{ orchestrator_namespace }}" apply -f -
+      changed_when: true
+
+    - name: Build osbs-buildroot
+      command: oc --namespace "{{ orchestrator_namespace }}"
+                  start-build osbs-buildroot
+      changed_when: true

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -2,7 +2,7 @@
 ### General settings
 
 # OSBS-Box repository and version (branch, tag or commit ID)
-# Used by openshift when building koji images
+# Used by openshift when building images
 osbs_box_repo: https://github.com/containerbuildsystem/osbs-box
 osbs_box_version: a-new-box
 
@@ -43,6 +43,8 @@ registry_namespace: osbs-registry
 
 
 ### Repositories and versions for OSBS components
+
+buildroot_python_version: 3
 
 atomic_reactor_repo: https://github.com/containerbuildsystem/atomic-reactor
 atomic_reactor_version: master

--- a/openshift/configs/koji-builder-osbs.conf.j2
+++ b/openshift/configs/koji-builder-osbs.conf.j2
@@ -6,7 +6,7 @@ openshift_required_version = 3.6.0
 [default]
 openshift_url = {{ openshift_url }}
 namespace = {{ orchestrator_namespace }}
-build_from = image:osbs-box/buildroot
+build_from = imagestream:osbs-buildroot:latest
 reactor_config_map = reactor-config-map
 build_type = prod
 can_orchestrate = true
@@ -19,7 +19,7 @@ password = {{ openshift_password }}
 [scratch]
 openshift_url = {{ openshift_url }}
 namespace = {{ orchestrator_namespace }}
-build_from = image:osbs-box/buildroot
+build_from = imagestream:osbs-buildroot:latest
 reactor_config_map = reactor-config-map
 build_type = prod
 can_orchestrate = true

--- a/openshift/configs/reactor-config-map.yaml.j2
+++ b/openshift/configs/reactor-config-map.yaml.j2
@@ -41,7 +41,7 @@ source_registry:
   url: https://{{ registry_ip }}:5000/
   insecure: true
 
-sources_command: rhpkg sources
+sources_command: fedpkg sources
 
 required_secrets:
   - kojisecret

--- a/openshift/params/osbs-box.env.j2
+++ b/openshift/params/osbs-box.env.j2
@@ -7,6 +7,8 @@ KOJI_FILES_DIR="{{ koji_files_dir }}"
 KOJI_DB_DATA_DIR="{{ koji_db_data_dir }}"
 REGISTRY_DATA_DIR="{{ registry_data_dir }}"
 
+PY_VER="{{ buildroot_python_version }}"
+
 ATOMIC_REACTOR_PIP_REF="git+{{ atomic_reactor_repo }}@{{ atomic_reactor_version }}"
 OSBS_CLIENT_PIP_REF="git+{{ osbs_client_repo }}@{{ osbs_client_version }}"
 KOJI_CONTAINERBUILD_PIP_REF="git+{{ koji_containerbuild_repo }}@{{ koji_containerbuild_version }}"

--- a/openshift/templates/osbs-buildroot.yaml
+++ b/openshift/templates/osbs-buildroot.yaml
@@ -1,0 +1,88 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: osbs-buildroot
+  description: >
+    Buildroot is the image which is pulled and run by orchestrator to do
+    an image build. It should live in the orchestrator namespace.
+
+labels:
+  build: osbs-buildroot
+
+parameters:
+  - name: OSBS_BOX_REPO
+    description: Repository to build the image from
+    value: https://github.com/containerbuildsystem/osbs-box
+    required: true
+
+  - name: OSBS_BOX_VERSION
+    description: Branch/tag/commit within the repository specified above
+    value: master
+    required: true
+
+  - name: PY_VER
+    description: Version of python to use (2 or 3), default 3
+    value: "3"
+    required: false
+
+  - name: ATOMIC_REACTOR_PIP_REF
+    description: >
+      Pip URL to install atomic-reactor from (git+<repo>[@<version>])
+    value: git+https://github.com/containerbuildsystem/atomic-reactor
+    required: true
+
+  - name: OSBS_CLIENT_PIP_REF
+    description: >
+      Pip URL to install osbs-client from (git+<repo>[@<version>])
+    value: git+https://github.com/containerbuildsystem/osbs-client
+    required: true
+
+  - name: DOCKERFILE_PARSE_PIP_REF
+    description: >
+      Pip URL to install dockerfile-parse from (git+<repo>[@<version>])
+    value: git+https://github.com/containerbuildsystem/dockerfile-parse
+    required: true
+
+  - name: DOCKPULP_PIP_REF
+    description: >
+      Pip URL to install dockpulp from (git+<repo>[@<version>])
+    value: git+https://github.com/release-engineering/dockpulp
+    required: true
+
+objects:
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: osbs-buildroot
+    spec: {}
+
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: osbs-buildroot
+    spec:
+      source:
+        type: Git
+        git:
+          uri: ${OSBS_BOX_REPO}
+          ref: ${OSBS_BOX_VERSION}
+        contextDir: osbs-buildroot
+      strategy:
+        type: Docker
+        dockerStrategy:
+          noCache: true
+          buildArgs:
+            - name: PY_VER
+              value: ${PY_VER}
+            - name: ATOMIC_REACTOR_PIP_REF
+              value: ${ATOMIC_REACTOR_PIP_REF}
+            - name: OSBS_CLIENT_PIP_REF
+              value: ${OSBS_CLIENT_PIP_REF}
+            - name: DOCKERFILE_PARSE_PIP_REF
+              value: ${DOCKERFILE_PARSE_PIP_REF}
+            - name: DOCKPULP_PIP_REF
+              value: ${DOCKPULP_PIP_REF}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: osbs-buildroot:latest

--- a/osbs-buildroot/Dockerfile
+++ b/osbs-buildroot/Dockerfile
@@ -1,0 +1,43 @@
+FROM golang:buster AS build
+
+RUN go get -v "github.com/openshift/imagebuilder/cmd/imagebuilder"
+
+
+FROM registry.fedoraproject.org/fedora:30
+
+# Choose python version
+ARG PY_VER="3"
+RUN if [ "$PY_VER" != 3 ]; then \
+        dnf -y install "python${PY_VER}" \
+                       "python${PY_VER}-pip"; \
+    fi
+
+# Install non-OSBS buildroot components
+COPY --from=build "/go/bin/imagebuilder" "/usr/bin/imagebuilder"
+RUN dnf -y install "fedpkg-minimal" \
+                   "python${PY_VER}-rpm" \
+                   "python${PY_VER}-koji" \
+                   "python${PY_VER}-libmodulemd"
+
+# Install stuff that will be needed for pip-installing OSBS components from git
+RUN dnf -y install "git-core" \
+                   "python${PY_VER}-devel" \
+                   "krb5-devel" \
+                   "xz-devel" \
+                   "gcc" && \
+    dnf clean all
+
+# Pip URLs for OSBS components (git+<repo>[@<version>])
+ARG ATOMIC_REACTOR_PIP_REF
+ARG OSBS_CLIENT_PIP_REF
+ARG DOCKERFILE_PARSE_PIP_REF
+ARG DOCKPULP_PIP_REF
+
+# Install OSBS components from git
+ENV PIP_PREFIX="/usr"
+RUN pip${PY_VER} install "$ATOMIC_REACTOR_PIP_REF" \
+                         "$OSBS_CLIENT_PIP_REF" \
+                         "$DOCKERFILE_PARSE_PIP_REF" \
+                         "$DOCKPULP_PIP_REF"
+
+CMD ["atomic-reactor", "--verbose", "inside-build"]


### PR DESCRIPTION
* OSBS-8117

It is a fedora-based image which installs all (hopefully) buildroot components.

Installing `atomic-reactor` with pip brings a slight complication in that both `docker` and `docker-py` end up getting installed as dependencies, which breaks things horribly. Temporary workaround in Dockerfile.

With this PR, OSBS-Box should become usable for container builds (again).

TODO:
* [x] Update README
* [x] Fix atomic-reactor pip installation ([here](https://github.com/containerbuildsystem/atomic-reactor/pull/1285))