### PR TITLE
Change the default osbs-box version

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -4,7 +4,7 @@
 # OSBS-Box repository and version (branch, tag or commit ID)
 # Used by openshift when building images
 osbs_box_repo: https://github.com/containerbuildsystem/osbs-box
-osbs_box_version: a-new-box
+osbs_box_version: master
 
 # Allow ansible to install packages?
 # If true, you may need to run the generate-certs playbook with


### PR DESCRIPTION
Now that a-new-box has been merged into master, it can be master.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>