### PR TITLE
Allow playbooks to work for remote machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 overrides.yaml
+inventory.ini

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ oc cluster up
 ```
 
 For more details, refer to
-[the OKD documentation](https://docs.okd.io/latest/getting_started/administrators.html#running-in-a-docker-container).
+[this document](https://github.com/openshift/origin/blob/release-3.11/docs/cluster_up_down.md).
 
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OSBS-Box
 
-An OpenShift based project that provides a local environment for testing OSBS components.
+An OpenShift based project that provides an environment for testing OSBS components.
+Can be deployed locally using the [example inventory](inventory-example.ini), or remotely using
+your own inventory.
 
 
 ## Basic usage
@@ -8,6 +10,9 @@ An OpenShift based project that provides a local environment for testing OSBS co
 Run a simple container build on your OSBS-Box:
 
 ```bash
+$ # If running remotely, first log in to the OpenShift server or ssh into the remote machine
+$ oc login --server https://<IP address>:8443 -u osbs -p osbs
+
 $ # Get URL of container registry
 $ OSBS_REGISTRY=$(oc -n osbs-registry get route osbs-registry --output jsonpath='{ .spec.host }')
 
@@ -23,6 +28,8 @@ $ oc -n osbs-koji rsh dc/koji-client \
           git://github.com/chmeliik/docker-hello-world#origin/osbs-box-basic \
           --git-branch osbs-box-basic
 ```
+
+When logging into the server, you will likely need to use the `--insecure-skip-tls-verify` flag.
 
 If your version of `skopeo` does not support the `--all` flag, you might want to use `skopeo-lite`
 instead. More on that [here](#Skopeo-lite).
@@ -45,7 +52,10 @@ For more details, refer to
 
 ### Prerequisites
 
+__On your machine__
 * Ansible
+
+__On the target machine__
 * pyOpenSSL >= 0.15 (for the `openssl_*` ansible modules)
 * an OpenShift cluster, as described above
 
@@ -54,14 +64,15 @@ For more details, refer to
 
 1. If you haven't already, `git clone` this repository
 2. Take a look at the [configuration file](group_vars/all.yaml)
-3. Run `ansible-playbook deploy.yaml`
+3. Provide an inventory file, or use the example one
+4. Run `ansible-playbook deploy.yaml -i <inventory file>`
     * If you are sure that you do not need to re-generate certificates, use `--tags=openshift`
 
 __NOTE__: Rather than changing the configuration in __group_vars/all.yaml__, you might want to
 create a file containing your overrides (e.g. __overrides.yaml__) and run the playbooks like this:
 
 ```bash
-$ ansible-playbook <playbook> -e '@overrides.yaml'
+$ ansible-playbook <playbook> -i <inventory> -e '@overrides.yaml'
 ```
 
 __NOTE__: The __deploy.yaml__ playbook only starts the build, it does not wait for the entire
@@ -76,7 +87,7 @@ web console / CLI.
 
 ### OpenShift console
 
-Located at https://localhost:8443/console/ by default.
+Located at https://localhost:8443/console/ by default (if running locally).
 
 You will see all the OSBS-Box namespaces here (by default, they are called `osbs-*`). After
 entering a namespace, you will see all the running pods, you can view their logs, open terminals
@@ -84,12 +95,13 @@ in them etc.
 
 ### OpenShift CLI
 
-Generally, anything you can do in the console, you can do with `oc`.  Just make sure you are in
-the right project.
+Generally, anything you can do in the console, you can do with `oc`. Just make sure you are logged
+into the server and in the right project.
 
 To run a command in a container from the command line (for example, `koji hello` on the client):
 
 ```bash
+$ oc login --server <server> -u osbs -p osbs  # If not yet logged in
 $ oc rsh dc/koji-client koji hello  # dc is short for deploymentconfig
 $ oc -n osbs-koji rsh dc/koji-client koji hello  # From a project other than osbs-koji
 ```
@@ -104,9 +116,9 @@ information about your Koji instance.
 
 To log in to the website, you will first need to import a client certificate into your browser.
 These certificates are generated during deployment and can be found in the koji certificates
-directory (__~/.local/share/osbs-box/certificates/koji/__ by default).  There is one for each
-koji user (by default, only _kojiadmin_ and _kojiosbs_ are users, but logging in creates a user
-automatically).
+directory on the target machine (__~/.local/share/osbs-box/certificates/koji/__ by default).
+There is one for each koji user (by default, only _kojiadmin_ and _kojiosbs_ are users, but
+logging in creates a user automatically).
 
 ### Koji CLI (local)
 
@@ -158,13 +170,16 @@ Or `docker`:
 ```bash
 $ docker build skopeo-lite/ --tag skopeo-lite
 
-$ # Get IP of container registry, your firewall will likely prevent docker from accessing the URL
-$ REGISTRY_IP=$(oc -n osbs-registry get svc osbs-registry --output jsonpath='{ .spec.clusterIP }')
+$ # If you are on the target machine, you might need to use the registry IP instead
+$ OSBS_REGISTRY=$(oc -n osbs-registry get svc osbs-registry --output jsonpath='{ .spec.clusterIP }')
+
+$ # Otherwise, use the URL
+$ OSBS_REGISTRY=$(oc -n osbs-registry get route osbs-registry --output jsonpath='{ .spec.host }')
 
 $ # Copy image to container registry
 $ docker run --rm -ti \
       skopeo-lite copy docker://registry.fedoraproject.org/fedora:30 \
-                       docker://${REGISTRY_IP}:5000/fedora:30 \
+                       docker://${OSBS_REGISTRY}:5000/fedora:30 \
                        --dest-tls-verify=false
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,14 +188,21 @@ $ docker run --rm -ti \
 
 In general, there are two reasons why you might want to update your OSBS-Box instance:
 
-* Changes in OSBS-Box itself
-* Changes in other OSBS components
+1. Changes in OSBS-Box itself
+2. Changes in other OSBS components
 
-In both cases, what you want to do is:
+For case 1, your best bet is to rerun the entire deployment:
+```bash
+$ ansible-playbook deploy.yaml -i <inventory> -e <overrides>
+```
 
-1. Specify your overrides in a file
-    * e.g. __repo__, __branch__ for the OSBS components you want to test
-2. Run the __deploy.yaml__ playbook with your overrides
+For case 2, usually you will only need:
+```bash
+$ ansible-playbook deploy.yaml -i <inventory> -e <overrides> --tags=koji,buildroot
+```
+In fact, it might be desirable to run the update like this to avoid having any potential manual
+changes to the reactor config map overwritten. But if you are not sure, running the full playbook
+or at least `--tags=openshift` will work.
 
 __NOTE__: When working on OSBS-Box code, to test changes concerning any of the pieces used to
 build Docker images, you will need to __push the changes first__ before running the playbook,

--- a/cleanup.yaml
+++ b/cleanup.yaml
@@ -1,5 +1,5 @@
 - name: Prepare for cleanup
-  hosts: localhost
+  hosts: osbs_box_host
   tags:
     - always
 
@@ -14,7 +14,7 @@
 
 
 - name: Delete koji
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   tags:
     - koji
@@ -45,7 +45,7 @@
 
 
 - name: Delete docker registry
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   tags:
     - registry
@@ -72,7 +72,7 @@
 
 
 - name: Delete OSBS orchestrator and worker namespaces
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   tags:
     - namespaces
@@ -92,7 +92,7 @@
 
 
 - name: Delete persistent volume data
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   become: true
   tags:
@@ -126,7 +126,7 @@
 
 
 - name: Delete remaining OSBS-Box data
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   tags:
     - never

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,5 +1,5 @@
 - name: Generate certificates for OSBS-Box
-  hosts: localhost
+  hosts: osbs_box_host
   tags:
     - certificates
 
@@ -18,7 +18,7 @@
 
 
 - name: Prepare for deployment of openshift applications
-  hosts: localhost
+  hosts: osbs_box_host
   tags:
     - koji
     - registry
@@ -49,7 +49,7 @@
 
 
 - name: Run koji containers on openshift
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   vars:
     # This is a constant, please do not override
@@ -153,7 +153,7 @@
 
 
 - name: Run registry container on openshift
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   tags:
     - registry
@@ -206,7 +206,7 @@
 
 
 - name: Set up OSBS orchestrator and worker namespaces
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   vars:
     # This is a constant, please do not override
@@ -292,7 +292,7 @@
 
 
 - name: Build OSBS buildroot
-  hosts: localhost
+  hosts: osbs_box_host
   gather_facts: false
   tags:
     - buildroot

--- a/inventory-example.ini
+++ b/inventory-example.ini
@@ -1,0 +1,3 @@
+[osbs_box_host]
+# OSBS-Box is intended for use with only a single host
+localhost   ansible_connection=local


### PR DESCRIPTION
Related to OSBS-7600

This is a sort of breaking change in the sense that you now need to specify inventory files when running the `deploy` and `cleanup` playbooks.