### PR TITLE
README: require ansible >= 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For more details, refer to
 ### Prerequisites
 
 __On your machine__
-* Ansible
+* ansible >= 2.8
 
 __On the target machine__
 * pyOpenSSL >= 0.15 (for the `openssl_*` ansible modules)


### PR DESCRIPTION
The `openssl_certificate_info` module is not available prior to version
2.8, the alternative way of doing certificate checks is already
deprecated.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>